### PR TITLE
Update to maven-settings-xml-action version to 21

### DIFF
--- a/.github/workflows/security-java11.yaml
+++ b/.github/workflows/security-java11.yaml
@@ -29,7 +29,7 @@ jobs:
         run: java -version
 
       - name: Generate Maven settings.xml file to access GitHub Packages
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v21
         with:
           repositories: >
             [

--- a/.github/workflows/security-java8.yaml
+++ b/.github/workflows/security-java8.yaml
@@ -29,7 +29,7 @@ jobs:
         run: java -version
 
       - name: Generate Maven settings.xml file to access GitHub Packages
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v21
         with:
           repositories: >
             [


### PR DESCRIPTION
## Description

- feature/maven-settings-xml-action-version change to v21 so node12 warning is not shown

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
